### PR TITLE
Invalid Type of ShakeClass

### DIFF
--- a/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyCameraShake.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyCameraShake.h
@@ -26,7 +26,7 @@ class ALSV4_CPP_API UALSAnimNotifyCameraShake : public UAnimNotify
 
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = AnimNotify)
-	TSubclassOf<UMatineeCameraShake> ShakeClass;
+	TSubclassOf<UCameraShakeBase> ShakeClass;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = AnimNotify)
 	float Scale = 1.0f;


### PR DESCRIPTION
in the ALSAnimNotifyCameraShake.cpp line 20, ClientStartCameraShake, take a UCameraShakeBase subclass

but the ShakeClass is a UMatineeCameraShake, 
and u get error and u cant build the plugin

so u need to change it, in order to build for 4.27.0