### PR TITLE
Allow for configuring a reversible pelvis bone on the ragdoll system

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/ALSBaseCharacter.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSBaseCharacter.cpp
@@ -727,7 +727,13 @@ void AALSBaseCharacter::SetActorLocationDuringRagdoll(float DeltaTime)
 	// Determine wether the ragdoll is facing up or down and set the target rotation accordingly.
 	const FRotator PelvisRot = GetMesh()->GetSocketRotation(FName(TEXT("Pelvis")));
 
-	bRagdollFaceUp = PelvisRot.Roll < 0.0f;
+	if (bReversedPelvis) {
+		bRagdollFaceUp = PelvisRot.Roll > 0.0f;
+	} else
+	{
+		bRagdollFaceUp = PelvisRot.Roll < 0.0f;
+	}
+
 
 	const FRotator TargetRagdollRotation(0.0f, bRagdollFaceUp ? PelvisRot.Yaw - 180.0f : PelvisRot.Yaw, 0.0f);
 

--- a/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
@@ -584,6 +584,10 @@ protected:
 
 	/** Ragdoll System */
 
+	/** If the skeleton uses a reversed pelvis bone, flip the calculation operator */
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "ALS|Ragdoll System")
+	bool bReversedPelvis = false;
+
 	/** If player hits to the ground with a specified amount of velocity, switch to ragdoll state */
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category = "ALS|Ragdoll System")
 	bool bRagdollOnLand = false;


### PR DESCRIPTION
Some Marketplace Assets do not follow the standard UE4 Mannequin bone structure and have a reversed pelvis. This adds a BP exposed boolean to flip the operator on the calculation from `<` to `>` that resolves this issue. Defaulting to the current standard model of `<` being the operator.