### PR TITLE
Make als more extensible

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
@@ -292,6 +292,7 @@ void UALSCharacterAnimInstance::SetFootLocking(float DeltaSeconds, FName EnableF
                                                FName IKFootBone, float& CurFootLockAlpha, bool& UseFootLockCurve,
                                                FVector& CurFootLockLoc, FRotator& CurFootLockRot)
 {
+	if (!bUseIKFootLocking) return;
 	if (GetCurveValue(EnableFootIKCurve) <= 0.0f)
 	{
 		return;

--- a/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/ALSCharacterAnimInstance.cpp
@@ -292,7 +292,11 @@ void UALSCharacterAnimInstance::SetFootLocking(float DeltaSeconds, FName EnableF
                                                FName IKFootBone, float& CurFootLockAlpha, bool& UseFootLockCurve,
                                                FVector& CurFootLockLoc, FRotator& CurFootLockRot)
 {
-	if (!bUseIKFootLocking) return;
+	if (!bUseIKFootLocking)
+	{
+		return;
+	}
+
 	if (GetCurveValue(EnableFootIKCurve) <= 0.0f)
 	{
 		return;

--- a/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
@@ -360,13 +360,13 @@ protected:
 
 	void UpdateCharacterMovement();
 
-	void UpdateGroundedRotation(float DeltaTime);
+	virtual void UpdateGroundedRotation(float DeltaTime);
 
-	void UpdateInAirRotation(float DeltaTime);
+	virtual void UpdateInAirRotation(float DeltaTime);
 
 	/** Utils */
 
-	void SmoothCharacterRotation(FRotator Target, float TargetInterpSpeed, float ActorInterpSpeed, float DeltaTime);
+	virtual void SmoothCharacterRotation(FRotator Target, float TargetInterpSpeed, float ActorInterpSpeed, float DeltaTime);
 
 	float CalculateGroundedRotationRate() const;
 

--- a/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
@@ -266,6 +266,9 @@ protected:
 		ShowOnlyInnerProperties))
 	FALSAnimConfiguration Config;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Configuration|Foot IK")
+	bool bUseIKFootLocking = true;
+
 	/** Blend Curves */
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
@@ -297,9 +300,6 @@ protected:
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Dynamic Transition")
 	UAnimSequenceBase* TransitionAnim_L = nullptr;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Configuration|Foot IK")
-	bool bUseIKFootLocking = true;
 
 private:
 	FTimerHandle OnPivotTimer;

--- a/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
@@ -298,6 +298,9 @@ protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Dynamic Transition")
 	UAnimSequenceBase* TransitionAnim_L = nullptr;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Configuration|Dynamic Transition")
+	bool bUseIKFootLocking = true;
+
 private:
 	FTimerHandle OnPivotTimer;
 

--- a/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
@@ -298,7 +298,7 @@ protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Dynamic Transition")
 	UAnimSequenceBase* TransitionAnim_L = nullptr;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Configuration|Dynamic Transition")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Configuration|Foot IK")
 	bool bUseIKFootLocking = true;
 
 private:


### PR DESCRIPTION
I am using ALS for an FPS project -- i have set my character up with detached FPS arms and hidden portions of the third-person mesh. I do not wish to restrict player rotation speed, so I have also override three methods (please see overridden examples below). This resulted in undesirable movement in feet due to IK foot locking (please see attached video)

Overridden functions within child class

```

void AFPS_BaseCharacter::UpdateInAirRotation(float DeltaTime)
{
	const float InPitch = 0;
	const float InRoll = 0;
	const float TargetInterpSpeed = 0;
	const float ActorInterpSpeed = 15;
	SmoothCharacterRotation({InPitch, AimingRotation.Yaw, InRoll}, TargetInterpSpeed, ActorInterpSpeed, DeltaTime);
	InAirRotation = GetActorRotation();
}

void AFPS_BaseCharacter::SmoothCharacterRotation(FRotator Target, float TargetInterpSpeed, float ActorInterpSpeed,
	float DeltaTime)
{
	if (ViewMode != EALSViewMode::FirstPerson || UseSmoothCharacterRotation)
	{
		Super::SmoothCharacterRotation(Target, TargetInterpSpeed, ActorInterpSpeed, DeltaTime);
	}
	else
	{
		TargetRotation = Target;
		SetActorRotation(TargetRotation);
	}
}

void AFPS_BaseCharacter::UpdateGroundedRotation(float DeltaTime)
{
	const float InPitch = 0;
	const float InRoll = 0;
	const float TargetInterpSpeed = 1000;
	const float ActorInterpSpeed = 20;
	SmoothCharacterRotation({InPitch, AimingRotation.Yaw, InRoll}, TargetInterpSpeed, ActorInterpSpeed, DeltaTime);
}
```

Example of foot locking issue and resolution:

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/K3CkXPSF6zU/0.jpg)](https://www.youtube.com/watch?v=K3CkXPSF6zU)

https://www.youtube.com/watch?v=K3CkXPSF6zU

If I could make the foot IK update faster rather than disable it completely this would be more desirable, but I will settle for disabling it completely.

