### PR TITLE
Reduce allocations on footsteps

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
@@ -39,7 +39,12 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 		const FVector TraceEnd = FootLocation - MeshOwner->GetActorUpVector() * TraceLength;
 
 		FHitResult Hit;
-		TArray<AActor*> ActorsToIgnore;
+
+		check(IsInGameThread());
+		checkNoRecursion();
+		static TArray<AActor*> ActorsToIgnore;
+		ActorsToIgnore.Reset();
+
 		ActorsToIgnore.Add(MeshOwner);
 		ActorsToIgnore.Append(MeshOwner->Children);
 		if (UKismetSystemLibrary::LineTraceSingle(World, FootLocation, TraceEnd, TraceChannel, true, ActorsToIgnore,
@@ -52,7 +57,11 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 
 			const EPhysicalSurface SurfaceType = Hit.PhysMaterial.Get()->SurfaceType;
 
-			TArray<FALSHitFX*> HitFXRows;
+			check(IsInGameThread());
+			checkNoRecursion();
+			static TArray<FALSHitFX*> HitFXRows;
+			HitFXRows.Reset();
+
 			HitDataTable->GetAllRows<FALSHitFX>(FString(), HitFXRows);
 
 			FALSHitFX* HitFX = nullptr;


### PR DESCRIPTION
Make temp arrays static to reduce allocations during footstep
processing.