### PR TITLE
Revert footstep trace to kismet version

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
+++ b/Source/ALSV4_CPP/Private/Character/Animation/Notify/ALSAnimNotifyFootstep.cpp
@@ -10,6 +10,7 @@
 
 #include "Components/AudioComponent.h"
 #include "Engine/DataTable.h"
+#include "Kismet/KismetSystemLibrary.h"
 #include "Library/ALSCharacterStructLibrary.h"
 #include "PhysicalMaterials/PhysicalMaterial.h"
 #include "NiagaraSystem.h"
@@ -46,25 +47,8 @@ void UALSAnimNotifyFootstep::Notify(USkeletalMeshComponent* MeshComp, UAnimSeque
 
 		FHitResult Hit;
 
-		ECollisionChannel CollisionChannel = UEngineTypes::ConvertToCollisionChannel(TraceChannel);
-
-		FCollisionQueryParams Params(SCENE_QUERY_STAT(ALSFootstep), true /*bTraceComplex*/, MeshOwner);
-		Params.bReturnPhysicalMaterial = true;
-		for (auto& Child : MeshOwner->Children)
-		{
-			Params.AddIgnoredActor(Child);
-		}
-
-		bool const bHit = MeshComp->GetWorld() ? World->LineTraceSingleByChannel(Hit, FootLocation, TraceEnd, CollisionChannel, Params) : false;
-
-#if ENABLE_DRAW_DEBUG
-		if (MeshComp->GetWorld())
-		{
-			DrawDebugLineTraceSingle(MeshComp->GetWorld(), FootLocation, TraceEnd, DrawDebugType, bHit, Hit, TraceColor, TraceHitColor, DrawTime);
-		}
-#endif
-
-		if (bHit)
+		if (UKismetSystemLibrary::LineTraceSingle(MeshOwner /*used by bIgnoreSelf*/, FootLocation, TraceEnd, TraceChannel, true /*bTraceComplex*/, MeshOwner->Children,
+		                                          DrawDebugType, Hit, true /*bIgnoreSelf*/))
 		{
 			if (!Hit.PhysMaterial.Get())
 			{


### PR DESCRIPTION
There were compile issues in the change to reduce allocations in
footstep traces. Revert back to the kismet version, but use MeshOwner
as the world context object so that bIgnoreSelf can ignore it.  That
way MeshOwner->Children can be used directly as the rest of the ignore
list, avoiding the allocations.