### PR TITLE
Replace GetMyMovementComponent with GetMyMovementComponent

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/ALSBaseCharacter.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSBaseCharacter.cpp
@@ -16,7 +16,6 @@
 
 #include "Components/CapsuleComponent.h"
 #include "Curves/CurveFloat.h"
-#include "Character/ALSCharacterMovementComponent.h"
 #include "GameFramework/CharacterMovementComponent.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "Kismet/GameplayStatics.h"
@@ -41,6 +40,11 @@ AALSBaseCharacter::AALSBaseCharacter(const FObjectInitializer& ObjectInitializer
 	bUseControllerRotationYaw = 0;
 	bReplicates = true;
 	SetReplicatingMovement(true);
+}
+
+UALSCharacterMovementComponent* AALSBaseCharacter::GetMovementComponent() const
+{
+	return MyCharacterMovementComponent;
 }
 
 void AALSBaseCharacter::PostInitializeComponents()

--- a/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
@@ -14,6 +14,7 @@
 #include "Library/ALSCharacterStructLibrary.h"
 #include "Engine/DataTable.h"
 #include "GameFramework/Character.h"
+#include "Character/ALSCharacterMovementComponent.h"
 
 #include "ALSBaseCharacter.generated.h"
 
@@ -38,11 +39,7 @@ class ALSV4_CPP_API AALSBaseCharacter : public ACharacter
 public:
 	AALSBaseCharacter(const FObjectInitializer& ObjectInitializer);
 
-	UFUNCTION(BlueprintCallable, Category = "ALS|Movement")
-	FORCEINLINE class UALSCharacterMovementComponent* GetMyMovementComponent() const
-	{
-		return MyCharacterMovementComponent;
-	}
+	virtual UALSCharacterMovementComponent* GetMovementComponent() const override;
 
 	virtual void Tick(float DeltaTime) override;
 


### PR DESCRIPTION
Blueprint could get character movement component with `APawn::GetMovementComponent`.

What's more, we could consider replace all direct access to `MyMovementComponent` to `GetMovementComponent()`