### PR TITLE
fix(build): fix build/packages issue and update to comply with new c++ standards

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
@@ -7,6 +7,7 @@
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "InputMappingContext.h"
+#include "Engine/LocalPlayer.h"
 #include "AI/ALSAIController.h"
 #include "Character/ALSCharacter.h"
 #include "Character/ALSPlayerCameraManager.h"

--- a/Source/ALSV4_CPP/Public/AI/ALSAIController.h
+++ b/Source/ALSV4_CPP/Public/AI/ALSAIController.h
@@ -21,7 +21,7 @@ public:
 	AALSAIController();
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "AI")
-	UBehaviorTree* Behaviour = nullptr;
+	TObjectPtr<UBehaviorTree> Behaviour = nullptr;
 
 protected:
 	virtual void OnPossess(APawn* InPawn) override;

--- a/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSBaseCharacter.h
@@ -420,7 +420,7 @@ protected:
 protected:
 	/* Custom movement component*/
 	UPROPERTY()
-	UALSCharacterMovementComponent* MyCharacterMovementComponent;
+	TObjectPtr<UALSCharacterMovementComponent> MyCharacterMovementComponent;
 
 	/** Input */
 
@@ -503,7 +503,7 @@ protected:
 
 	/** Replicated Skeletal Mesh Information*/
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ALS|Skeletal Mesh", ReplicatedUsing = OnRep_VisibleMesh)
-	USkeletalMesh* VisibleMesh = nullptr;
+	TObjectPtr<USkeletalMesh> VisibleMesh = nullptr;
 
 	/** State Values */
 
@@ -604,7 +604,7 @@ protected:
 	float PreviousAimYaw = 0.0f;
 	
 	UPROPERTY(BlueprintReadOnly, Category = "ALS|Camera")
-	UALSPlayerCameraBehavior* CameraBehavior;
+	TObjectPtr<UALSPlayerCameraBehavior> CameraBehavior;
 
 	/** Last time the 'first' crouch/roll button is pressed */
 	float LastStanceInputTime = 0.0f;
@@ -620,5 +620,5 @@ protected:
 
 private:
 	UPROPERTY()
-	UALSDebugComponent* ALSDebugComponent = nullptr;
+	TObjectPtr<UALSDebugComponent> ALSDebugComponent = nullptr;
 };

--- a/Source/ALSV4_CPP/Public/Character/ALSCharacter.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSCharacter.h
@@ -53,13 +53,13 @@ protected:
 
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Component")
-	USceneComponent* HeldObjectRoot = nullptr;
+	TObjectPtr<USceneComponent> HeldObjectRoot = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Component")
-	USkeletalMeshComponent* SkeletalMesh = nullptr;
+	TObjectPtr<USkeletalMeshComponent> SkeletalMesh = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Component")
-	UStaticMeshComponent* StaticMesh = nullptr;
+	TObjectPtr<UStaticMeshComponent> StaticMesh = nullptr;
 
 private:
 	bool bNeedsColorReset = false;

--- a/Source/ALSV4_CPP/Public/Character/ALSPlayerCameraManager.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSPlayerCameraManager.h
@@ -44,10 +44,10 @@ protected:
 
 public:
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "ALS|Camera")
-	AALSBaseCharacter* ControlledCharacter = nullptr;
+	TObjectPtr<AALSBaseCharacter> ControlledCharacter = nullptr;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "ALS|Camera")
-	USkeletalMeshComponent* CameraBehavior = nullptr;
+	TObjectPtr<USkeletalMeshComponent> CameraBehavior = nullptr;
 
 protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ALS|Camera")
@@ -73,5 +73,5 @@ protected:
 
 private:
 	UPROPERTY()
-	UALSDebugComponent* ALSDebugComponent = nullptr;
+	TObjectPtr<UALSDebugComponent> ALSDebugComponent = nullptr;
 };

--- a/Source/ALSV4_CPP/Public/Character/ALSPlayerController.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSPlayerController.h
@@ -111,7 +111,7 @@ protected:
 	
 public:
 	/** Main character reference */
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "ALS")
 	AALSBaseCharacter* PossessedCharacter = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "ALS|Input")

--- a/Source/ALSV4_CPP/Public/Character/ALSPlayerController.h
+++ b/Source/ALSV4_CPP/Public/Character/ALSPlayerController.h
@@ -112,11 +112,11 @@ protected:
 public:
 	/** Main character reference */
 	UPROPERTY(BlueprintReadOnly, Category = "ALS")
-	AALSBaseCharacter* PossessedCharacter = nullptr;
+	TObjectPtr<AALSBaseCharacter> PossessedCharacter = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "ALS|Input")
-	UInputMappingContext* DefaultInputMappingContext = nullptr;
+	TObjectPtr<UInputMappingContext> DefaultInputMappingContext = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "ALS|Input")
-	UInputMappingContext* DebugInputMappingContext = nullptr;
+	TObjectPtr<UInputMappingContext> DebugInputMappingContext = nullptr;
 };

--- a/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/ALSCharacterAnimInstance.h
@@ -162,7 +162,7 @@ private:
 public:
 	/** References */
 	UPROPERTY(BlueprintReadOnly, Category = "Read Only Data|Character Information")
-	AALSBaseCharacter* Character = nullptr;
+	TObjectPtr<AALSBaseCharacter> Character = nullptr;
 
 	/** Character Information */
 	UPROPERTY(VisibleDefaultsOnly, BlueprintReadOnly, Category = "Read Only Data|Character Information", Meta = (
@@ -252,34 +252,34 @@ public:
 	/** Blend Curves */
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* DiagonalScaleAmountCurve = nullptr;
+	TObjectPtr<UCurveFloat> DiagonalScaleAmountCurve = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* StrideBlend_N_Walk = nullptr;
+	TObjectPtr<UCurveFloat> StrideBlend_N_Walk = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* StrideBlend_N_Run = nullptr;
+	TObjectPtr<UCurveFloat> StrideBlend_N_Run = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* StrideBlend_C_Walk = nullptr;
+	TObjectPtr<UCurveFloat> StrideBlend_C_Walk = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* LandPredictionCurve = nullptr;
+	TObjectPtr<UCurveFloat> LandPredictionCurve = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveFloat* LeanInAirCurve = nullptr;
+	TObjectPtr<UCurveFloat> LeanInAirCurve = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveVector* YawOffset_FB = nullptr;
+	TObjectPtr<UCurveVector> YawOffset_FB = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Blend Curves")
-	UCurveVector* YawOffset_LR = nullptr;
+	TObjectPtr<UCurveVector> YawOffset_LR = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Dynamic Transition")
-	UAnimSequenceBase* TransitionAnim_R = nullptr;
+	TObjectPtr<UAnimSequenceBase> TransitionAnim_R = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Dynamic Transition")
-	UAnimSequenceBase* TransitionAnim_L = nullptr;
+	TObjectPtr<UAnimSequenceBase> TransitionAnim_L = nullptr;
 
 	/** IK Bone Names */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Configuration|Anim Graph - Foot IK")
@@ -298,5 +298,5 @@ private:
 	bool bCanPlayDynamicTransition = true;
 
 	UPROPERTY()
-	UALSDebugComponent* ALSDebugComponent = nullptr;
+	TObjectPtr<UALSDebugComponent> ALSDebugComponent = nullptr;
 };

--- a/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyFootstep.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSAnimNotifyFootstep.h
@@ -27,7 +27,7 @@ class ALSV4_CPP_API UALSAnimNotifyFootstep : public UAnimNotify
 
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings")
-	UDataTable* HitDataTable;
+	TObjectPtr<UDataTable> HitDataTable;
 
 	static FName NAME_Foot_R;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Socket")

--- a/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSNotifyStateEarlyBlendOut.h
+++ b/Source/ALSV4_CPP/Public/Character/Animation/Notify/ALSNotifyStateEarlyBlendOut.h
@@ -25,7 +25,7 @@ class ALSV4_CPP_API UALSNotifyStateEarlyBlendOut : public UAnimNotifyState
 
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = AnimNotify)
-	UAnimMontage* ThisMontage = nullptr;
+	TObjectPtr<UAnimMontage> ThisMontage = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = AnimNotify)
 	float BlendOutTime = 0.25f;

--- a/Source/ALSV4_CPP/Public/Components/ALSDebugComponent.h
+++ b/Source/ALSV4_CPP/Public/Components/ALSDebugComponent.h
@@ -22,7 +22,7 @@ public:
 	
 	void BeginPlay() override;
 
-	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable)
+	UFUNCTION(BlueprintImplementableEvent, BlueprintCallable, Category = "ALS|Debug")
 	void OnPlayerControllerInitialized(APlayerController* Controller);
 
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType,

--- a/Source/ALSV4_CPP/Public/Components/ALSDebugComponent.h
+++ b/Source/ALSV4_CPP/Public/Components/ALSDebugComponent.h
@@ -135,7 +135,7 @@ protected:
 
 public:
 	UPROPERTY(BlueprintReadOnly, Category = "ALS|Debug")
-	AALSBaseCharacter* OwnerCharacter;
+	TObjectPtr<AALSBaseCharacter> OwnerCharacter;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ALS|Debug")
 	bool bSlomo = false;
@@ -147,13 +147,13 @@ public:
 	bool bShowCharacterInfo = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ALS|Debug")
-	USkeletalMesh* DebugSkeletalMesh = nullptr;
+	TObjectPtr<USkeletalMesh> DebugSkeletalMesh = nullptr;
 	
 	UPROPERTY(BlueprintReadOnly, Category = "ALS|Debug")
-	TArray<AALSBaseCharacter*> AvailableDebugCharacters;
+	TArray<TObjectPtr<AALSBaseCharacter>> AvailableDebugCharacters;
 
 	UPROPERTY(BlueprintReadOnly, Category = "ALS|Debug")
-	AALSBaseCharacter* DebugFocusCharacter = nullptr;
+	TObjectPtr<AALSBaseCharacter> DebugFocusCharacter = nullptr;
 private:
 	static bool bDebugView;
 
@@ -168,7 +168,7 @@ private:
 	bool bDebugMeshVisible = false;
 
 	UPROPERTY()
-	USkeletalMesh* DefaultSkeletalMesh = nullptr;
+	TObjectPtr<USkeletalMesh> DefaultSkeletalMesh = nullptr;
 	
 	/// Stores the index, which is used to select the next focused debug ALSBaseCharacter.
 	/// If no characters where found during BeginPlay the value should be set to INDEX_NONE.

--- a/Source/ALSV4_CPP/Public/Components/ALSMantleComponent.h
+++ b/Source/ALSV4_CPP/Public/Components/ALSMantleComponent.h
@@ -65,7 +65,7 @@ protected:
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Mantle System")
-	UTimelineComponent* MantleTimeline = nullptr;
+	TObjectPtr<UTimelineComponent> MantleTimeline = nullptr;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "ALS|Mantle System")
 	FALSMantleTraceSettings GroundedTraceSettings;
@@ -77,7 +77,7 @@ protected:
 	FALSMantleTraceSettings FallingTraceSettings;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "ALS|Mantle System")
-	UCurveFloat* MantleTimelineCurve;
+	TObjectPtr<UCurveFloat> MantleTimelineCurve;
 
 	static FName NAME_IgnoreOnlyPawn;
 	/** Profile to use to detect objects we allow mantling */
@@ -108,8 +108,8 @@ protected:
 
 private:
 	UPROPERTY()
-	AALSBaseCharacter* OwnerCharacter;
+	TObjectPtr<AALSBaseCharacter> OwnerCharacter;
 
 	UPROPERTY()
-	UALSDebugComponent* ALSDebugComponent = nullptr;
+	TObjectPtr<UALSDebugComponent> ALSDebugComponent = nullptr;
 };

--- a/Source/ALSV4_CPP/Public/Library/ALSAnimationStructLibrary.h
+++ b/Source/ALSV4_CPP/Public/Library/ALSAnimationStructLibrary.h
@@ -18,7 +18,7 @@ struct FALSDynamicMontageParams
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Dynamic Transition")
-	UAnimSequenceBase* Animation = nullptr;
+	TObjectPtr<UAnimSequenceBase> Animation = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS|Dynamic Transition")
 	float BlendInTime = 0.0f;
@@ -69,7 +69,7 @@ struct FALSTurnInPlaceAsset
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ALS|Turn In Place")
-	UAnimSequenceBase* Animation = nullptr;
+	TObjectPtr<UAnimSequenceBase> Animation = nullptr;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "ALS|Turn In Place")
 	float AnimatedAngle = 0.0f;

--- a/Source/ALSV4_CPP/Public/Library/ALSCharacterStructLibrary.h
+++ b/Source/ALSV4_CPP/Public/Library/ALSCharacterStructLibrary.h
@@ -30,7 +30,7 @@ struct FALSComponentAndTransform
 	FTransform Transform;
 
 	UPROPERTY(EditAnywhere, Category = "Character Struct Library")
-	UPrimitiveComponent* Component = nullptr;
+	TObjectPtr<UPrimitiveComponent> Component = nullptr;
 };
 
 USTRUCT(BlueprintType)
@@ -93,10 +93,10 @@ struct FALSMantleAsset
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
-	UAnimMontage* AnimMontage = nullptr;
+	TObjectPtr<UAnimMontage> AnimMontage = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
-	UCurveVector* PositionCorrectionCurve = nullptr;
+	TObjectPtr<UCurveVector> PositionCorrectionCurve = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
 	FVector StartingOffset;
@@ -126,10 +126,10 @@ struct FALSMantleParams
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
-	UAnimMontage* AnimMontage = nullptr;
+	TObjectPtr<UAnimMontage> AnimMontage = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
-	UCurveVector* PositionCorrectionCurve = nullptr;
+	TObjectPtr<UCurveVector> PositionCorrectionCurve = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Mantle System")
 	float StartingPosition = 0.0f;
@@ -177,10 +177,10 @@ struct FALSMovementSettings
 	float SprintSpeed = 0.0f;
 
 	UPROPERTY(EditAnywhere, Category = "Movement Settings")
-	UCurveVector* MovementCurve = nullptr;
+	TObjectPtr<UCurveVector> MovementCurve = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Movement Settings")
-	UCurveFloat* RotationRateCurve = nullptr;
+	TObjectPtr<UCurveFloat> RotationRateCurve = nullptr;
 
 	float GetSpeedForGait(const EALSGait Gait) const
 	{
@@ -231,7 +231,7 @@ struct FALSRotateInPlaceAsset
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, Category = "Rotation System")
-	UAnimSequenceBase* Animation = nullptr;
+	TObjectPtr<UAnimSequenceBase> Animation = nullptr;
 
 	UPROPERTY(EditAnywhere, Category = "Rotation System")
 	FName SlotName;


### PR DESCRIPTION
Add Categories to BP Exposed Functions and Properties.

Include missing LocalPlayer include.

As per https://docs.unrealengine.com/5.0/en-US/MigrationGuide/ updating from Native Pointers to TObjectPtr's. Without this change, errors like `Error: Native pointer usage in member declaration detected [[[AALSBaseCharacter*]]].  This is disallowed for the target/module, consider TObjectPtr as an alternative.` will occur if compiled outside of a path containing `/plugins/`. So if a user migrates to their own project source folder, or once Epic fixes up the TODO in https://github.com/EpicGames/UnrealEngine/blob/5.0.0-preview-1/Engine/Source/Programs/UnrealHeaderTool/Private/HeaderParser.cpp#L4144-L4152 to remove the current exclusion, users will face compilation errors. This commit future proof's this.