### PR TITLE
IsValid check for AALSPlayerController#OnPossess

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Replicated and optimized version of [Advanced Locomotion System V4](https://www.
 ## Supported Platforms
 - Windows
 - Linux
+- Console
 
-*Mac, Android, IOS, and console builds are not tested and supported at the moment. Use the plugin on those platforms with your own risk.*
+*Mac and mobile platforms are not tested and supported at the moment. Use the plugin on those platforms with your own risk.*
 
 ## Features
 - Fully implemented and optimized in C++. Implementation is based on latest marketplace release (V4) of ALS

--- a/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
@@ -26,6 +26,8 @@ void AALSPlayerController::OnPossess(APawn* NewPawn)
 
 	SetupInputs();
 
+	if (!IsValid(PossessedCharacter)) return;
+	
 	UALSDebugComponent* DebugComp = Cast<UALSDebugComponent>(PossessedCharacter->GetComponentByClass(UALSDebugComponent::StaticClass()));
 	if (DebugComp)
 	{


### PR DESCRIPTION
The editor was crashing whenever I used the Possess method due to AALSPlayerController#PossessedCharacter being a nullptr when the possessing pawn does not inherit AALSBaseCharacter.