### PR TITLE
fix : PossessedCharacter may be null .

### DIFF
--- a/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
+++ b/Source/ALSV4_CPP/Private/Character/ALSPlayerController.cpp
@@ -41,6 +41,8 @@ void AALSPlayerController::OnRep_Pawn()
 	PossessedCharacter = Cast<AALSBaseCharacter>(GetPawn());
 	SetupCamera();
 	SetupInputs();
+	
+	if (!PossessedCharacter) return;
 
 	UALSDebugComponent* DebugComp = Cast<UALSDebugComponent>(PossessedCharacter->GetComponentByClass(UALSDebugComponent::StaticClass()));
 	if (DebugComp)


### PR DESCRIPTION
The PossessedCharacter was null when I run it in dedicated server mode with more than 2 players. 
The patch seems to work fine for my current tests.