### PR TITLE
Resolves issue #458

### DIFF
--- a/ALSV4_CPP.uplugin
+++ b/ALSV4_CPP.uplugin
@@ -9,7 +9,7 @@
 	"CreatedByURL": "https://github.com/dyanikoglu",
 	"DocsURL": "https://github.com/dyanikoglu/ALS-Community",
 	"SupportURL": "https://github.com/dyanikoglu/ALS-Community/issues",
-	"EngineVersion": "5.1",
+	"EngineVersion": "5.1.0",
 	"EnabledByDefault": true,
 	"CanContainContent": true,
 	"IsBetaVersion": false,


### PR DESCRIPTION
Fixes warning: LogPluginManager: Warning: Engine version string in '.../ALSV4_CPP.uplugin' could not be parsed ('5.1')